### PR TITLE
Fixes #1 - example deps.edn "check"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The deps.edn file contains a basic setup and some common aliases:
    :test {:extra-paths ["test"]}
 
    ;; test.check 
-   :test {:extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
+   :check {:extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
 
    ;; benchmarking
    :bench {:extra-deps {criterium {:mvn/version "0.4.4"}}}}


### PR DESCRIPTION
README.md example edn.deps file has :test twice while source deps.edn has :test & :check as does repl example in README.md